### PR TITLE
Fix for 'Error opening block database.'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,12 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "hashicorp/precise64"
   config.vm.provision :shell, :path => "bootstrap.sh", privileged: false
-  config.vm.synced_folder "data/", "/home/vagrant/.bitcoin/"
+
+  # NFS synced_folder
+  # Fix for "Error opening block database."
+  # http://qiita.com/hshimo/items/3ca8444c33f339de66d2
+  config.vm.network :private_network, ip: "192.168.33.30"
+  config.vm.synced_folder "data/", "/home/vagrant/.bitcoin/", type: "nfs"
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1536"]


### PR DESCRIPTION
Fix for "Error opening block database."

debug.log

```
2015-01-10 17:29:50 init message: Loading block index...
2015-01-10 17:29:50 Opening LevelDB in /home/vagrant/.bitcoin/blocks/index
2015-01-10 17:29:50 IO error: /home/vagrant/.bitcoin/blocks/index: Invalid argument
```
